### PR TITLE
Fix url for non encrypted urls

### DIFF
--- a/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
+++ b/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
@@ -187,13 +187,21 @@ namespace YoutubeExtractor
                 if (queries.ContainsKey("s") || queries.ContainsKey("sig"))
                 {
                     requiresDecryption = queries.ContainsKey("s");
-                    string signature = queries.ContainsKey("s") ? queries["s"] : queries["sig"];
 
-                    url = string.Format("{0}&{1}={2}", queries["url"], SignatureQuery, signature);
+                    if (requiresDecryption)
+                    {
+                        string signature = queries.ContainsKey("s") ? queries["s"] : queries["sig"];
 
-                    string fallbackHost = queries.ContainsKey("fallback_host") ? "&fallback_host=" + queries["fallback_host"] : String.Empty;
+                        url = string.Format("{0}&{1}={2}", queries["url"], SignatureQuery, signature);
 
-                    url += fallbackHost;
+                        string fallbackHost = queries.ContainsKey("fallback_host") ? "&fallback_host=" + queries["fallback_host"] : String.Empty;
+
+                        url += fallbackHost;
+                    }
+                    else
+                    {
+                        url = NormalizeUrl(s);
+                    }
                 }
 
                 else
@@ -346,6 +354,11 @@ namespace YoutubeExtractor
             public bool RequiresDecryption { get; set; }
 
             public Uri Uri { get; set; }
+        }
+        
+        private static string NormalizeUrl(string url)
+        {
+            return url.Replace("\"", "").Replace("url=", "");
         }
     }
 }


### PR DESCRIPTION
When a video do not need a decryption, we only need to normalize the base url and should not try get a signature. For case requiresDecryption was false, it was thrown an error.